### PR TITLE
Update  fake data creation

### DIFF
--- a/packages/canner-helpers/src/createFakeData.js
+++ b/packages/canner-helpers/src/createFakeData.js
@@ -20,97 +20,132 @@ import type {Schema, SchemaMap} from './types';
 // createFakeData = (schema: Object, listLength: number) => *
 
 
-export default function createFakeData(schema: Schema | SchemaMap, listLength: number = 0) {
-  if (!schema) {
+export default function createFakeData(root: Schema | SchemaMap, listLength: number = 0) {
+  if (!root) {
     return null;
   }
-  if ('type' in schema) {
-    return loop(((schema: any): Schema), listLength);
+  const firstLevelKeys = getFirstLevelKeys(root);
+  return root.hasOwnProperty('type') ? loop(root, root.keyName): mapSchema(root, loop);
+
+  // Loop schema
+  function loop(schema: Schema, key: string) {
+    let result: any;
+
+    switch (schema.type) {
+      case 'object':
+        result = mapSchema(schema.items, loop);
+        result.__typename = result.__typename || null;
+        if (schema.keyName) {
+          result = {
+            [schema.keyName]: result
+          };
+        }
+        break;
+      case 'array':
+        result = [];
+        for (let i = 0; i < listLength; ++i) {
+          let item;
+          if (schema.items && schema.items.items) {
+            item = mapSchema(schema.items.items, loop);
+          } else {
+            item = schema.items.hasOwnProperty('type') ? loop(schema.items, schema.items.keyName): mapSchema(schema.items, loop);
+          }
+          if (typeof item === 'object' && key) {
+            item = {
+              ...item,
+              id: `${key}${i+1}`
+            };
+          } else if (schema.keyName) {
+            item = {
+              [key]: item,
+              id: `${key}${i+1}`
+            }
+          }
+          result.push(item);
+        }
+        break;
+      case 'number':
+        result = faker.random.number();
+        break;
+      case 'geoPoint':
+        result = {
+          __typename: null,
+          lat: faker.address.latitude(),
+          lng: faker.address.longitude(),
+          placeId: faker.random.uuid()
+        };
+        break;
+      case 'dateTime':
+        result = faker.date.past().toISOString();
+        break;
+      case 'file':
+        result = {
+          __typename: null,
+          contentType: faker.system.mimeType(),
+          size: faker.random.number(),
+          name: faker.system.commonFileName(),
+          url: faker.internet.url()
+        };
+        break;
+      case 'image':
+        result = {
+          __typename: null,
+          contentType: 'image/jpeg',
+          size: faker.random.number(),
+          name: faker.system.commonFileName(),
+          url: faker.image.imageUrl()
+        };
+        break;
+      case 'boolean':
+        result = faker.random.boolean();
+        break;
+      case 'string':
+        result = faker.random.word();
+        break;
+      case 'relation': {
+        result = getRelation(schema, firstLevelKeys, listLength);
+        break;
+      }
+      case 'json': {
+        result = {};
+        break;
+      }
+      default:
+        invariant(true, `unsupport type ${schema.type}`);
+        break;
+    }
+    return result;
   }
-  return mapSchema(((schema: any): SchemaMap), (schema: Schema) => loop(schema, listLength));
 }
 
+function getFirstLevelKeys(root: Schema | SchemaMap) {
+  if ('type' in root) {
+    return root.items ? Object.keys(root.items) : {};
+  }
+  return Object.keys(root);
+}
 
-function loop(schema: Schema, listLength: number) {
+function getRelation(schema: Schema, firstLevelKeys: any, listLength: number) {
+  const {type, to} = schema.relation;
+  const isInFirstLevel = Array.isArray(firstLevelKeys) && firstLevelKeys.indexOf(to) > -1 && listLength > 0;
   let result: any;
 
-  switch (schema.type) {
-    case 'object':
-      result = mapSchema(schema.items, (schema: Schema) => loop(schema, listLength));
-      result.__typename = result.__typename || null;
-      if (schema.keyName) {
-        result = {
-          [schema.keyName]: result
-        };
-      }
-      break;
-    case 'array':
-      result = [];
-      for (let i = 0; i < listLength; ++i) {
-        if (schema.items && schema.items.items) {
-          result.push(mapSchema(schema.items.items, (schema: Schema) => loop(schema, listLength)));
-        } else {
-          result.push(loop(schema.items, listLength));
+  switch (type) {
+    case 'toMany':
+      result = {};
+      if (isInFirstLevel) {
+        for(let i = 0; i < listLength; ++i) {
+          result[`${to}${i}`] = Math.random() >= 0.5;
         }
       }
       break;
-    case 'number':
-      result = faker.random.number();
-      break;
-    case 'geoPoint':
-      result = {
-        __typename: null,
-        lat: faker.address.latitude(),
-        lng: faker.address.longitude(),
-        placeId: faker.random.uuid()
-      };
-      break;
-    case 'dateTime':
-      result = faker.date.past().toISOString();
-      break;
-    case 'file':
-      result = {
-        __typename: null,
-        contentType: faker.system.mimeType(),
-        size: faker.random.number(),
-        name: faker.system.commonFileName(),
-        url: faker.internet.url()
-      };
-      break;
-    case 'image':
-      result = {
-        __typename: null,
-        contentType: 'image/jpeg',
-        size: faker.random.number(),
-        name: faker.system.commonFileName(),
-        url: faker.image.imageUrl()
-      };
-      break;
-    case 'boolean':
-      result = faker.random.boolean();
-      break;
-    case 'string':
-      result = faker.random.word();
-      break;
-    case 'relation': {
-      const {type} = schema.relation;
-      switch (type) {
-        case 'toMany':
-          result = [];
-          break;
-        case 'toOne':
-        default:
-          result = null;
-          break;
-      }
-      break;
-    }
-    case 'json': {
-      result = {};
-      break;
-    }
+    case 'toOne':
     default:
-      invariant(true, `unsupport type ${schema.type}`);
+      if (isInFirstLevel) {
+        result = `${to}${Math.floor(Math.random() * listLength) + 1}`;
+      } else {
+        result = null;
+      }
       break;
   }
   return result;

--- a/packages/canner-helpers/src/createFakeData.js
+++ b/packages/canner-helpers/src/createFakeData.js
@@ -113,12 +113,6 @@ function getArrayData(schema: Schema, key: string, listLength: number, loop: Fun
       item = mapSchema(schema.items.items, loop);
     } else {
       item = schema.items.hasOwnProperty('type') ? loop(schema.items, schema.items.keyName): mapSchema(schema.items, loop);
-
-      if (schema.items.keyName) {
-        item = {
-          [schema.items.keyName]: item
-        }
-      }
     }
 
     if (typeof item === 'object' && key) {

--- a/packages/canner-helpers/src/createFakeData.js
+++ b/packages/canner-helpers/src/createFakeData.js
@@ -42,27 +42,7 @@ export default function createFakeData(root: Schema | SchemaMap, listLength: num
         }
         break;
       case 'array':
-        result = [];
-        for (let i = 0; i < listLength; ++i) {
-          let item;
-          if (schema.items && schema.items.items) {
-            item = mapSchema(schema.items.items, loop);
-          } else {
-            item = schema.items.hasOwnProperty('type') ? loop(schema.items, schema.items.keyName): mapSchema(schema.items, loop);
-          }
-          if (typeof item === 'object' && key) {
-            item = {
-              ...item,
-              id: `${key}${i+1}`
-            };
-          } else if (schema.keyName) {
-            item = {
-              [key]: item,
-              id: `${key}${i+1}`
-            }
-          }
-          result.push(item);
-        }
+        result = getArrayData(schema, key, listLength, loop);
         break;
       case 'number':
         result = faker.random.number();
@@ -123,6 +103,33 @@ function getFirstLevelKeys(root: Schema | SchemaMap) {
     return root.items ? Object.keys(root.items) : {};
   }
   return Object.keys(root);
+}
+
+function getArrayData(schema: Schema, key: string, listLength: number, loop: Function) {
+  const result = [];
+  for (let i = 0; i < listLength; ++i) {
+    let item;
+    if (schema.items && schema.items.items) {
+      item = mapSchema(schema.items.items, loop);
+    } else {
+      item = schema.items.hasOwnProperty('type') ? loop(schema.items, schema.items.keyName): mapSchema(schema.items, loop);
+
+      if (schema.items.keyName) {
+        item = {
+          [schema.items.keyName]: item
+        }
+      }
+    }
+
+    if (typeof item === 'object' && key) {
+      item = {
+        ...item,
+        id: `${key}${i+1}`
+      };
+    }
+    result.push(item);
+  }
+  return result;
 }
 
 function getRelation(schema: Schema, firstLevelKeys: any, listLength: number) {

--- a/packages/canner-helpers/src/createFakeData.js
+++ b/packages/canner-helpers/src/createFakeData.js
@@ -36,16 +36,21 @@ function loop(schema: Schema, listLength: number) {
 
   switch (schema.type) {
     case 'object':
-      result = mapSchema(schema.items, loop);
+      result = mapSchema(schema.items, (schema: Schema) => loop(schema, listLength));
       result.__typename = result.__typename || null;
+      if (schema.keyName) {
+        result = {
+          [schema.keyName]: result
+        };
+      }
       break;
     case 'array':
       result = [];
       for (let i = 0; i < listLength; ++i) {
         if (schema.items && schema.items.items) {
-          result.push(mapSchema(schema.items.items, loop));
+          result.push(mapSchema(schema.items.items, (schema: Schema) => loop(schema, listLength)));
         } else {
-          result.push(loop(schema.items, 1));
+          result.push(loop(schema.items, listLength));
         }
       }
       break;

--- a/packages/canner-helpers/src/types.js
+++ b/packages/canner-helpers/src/types.js
@@ -4,6 +4,7 @@ type ObjectSchema = {
   items: SchemaMap;
   type: 'object';
   ui: string;
+  keyName: string;
   __typename: string;
 }
 

--- a/packages/canner-helpers/src/types.js
+++ b/packages/canner-helpers/src/types.js
@@ -4,7 +4,7 @@ type ObjectSchema = {
   items: SchemaMap;
   type: 'object';
   ui: string;
-  keyName: string;
+  keyName?: string;
   __typename: string;
 }
 
@@ -12,21 +12,25 @@ type ArraySchema = {
   items: Schema;
   type: 'array';
   ui: string;
+  keyName?: string;
 }
 
 type StringSchema = {
   type: 'string';
   ui: string;
+  keyName?: string;
 }
 
 type NumberSchema = {
   type: 'number';
   ui: string;
+  keyName?: string;
 }
 
 type BooleanSchema = {
   type: 'boolean';
   ui: string;
+  keyName?: string;
 }
 
 type RelationSchema = {
@@ -35,24 +39,28 @@ type RelationSchema = {
   relation: {
     type: string;
     to: string;
-  }
+  };
+  keyName?: string;
 };
 
 type GeoPointSchema = {
-  type: 'geoPoint',
-
+  type: 'geoPoint';
+  keyName?: string;
 }
 
 type DateTimeSchema = {
-  type: 'dateTime'
+  type: 'dateTime';
+  keyName?: string;
 }
 
 type FileSchema = {
-  type: 'file',
+  type: 'file';
+  keyName?: string;
 }
 
 type ImageScheme = {
-  type: 'image'
+  type: 'image';
+  keyName?: string;
 }
 
 export type Schema = ArraySchema | ObjectSchema | StringSchema | BooleanSchema | NumberSchema | RelationSchema

--- a/packages/canner-helpers/src/utils.js
+++ b/packages/canner-helpers/src/utils.js
@@ -6,7 +6,7 @@ import type {SchemaMap} from './types';
 export function mapSchema(schemaMap: SchemaMap, fn: Function): any {
   return Object.keys(schemaMap || {})
     .reduce((result: any, key: string) => {
-      result[key] = fn(schemaMap[key]);
+      result[key] = fn(schemaMap[key], key);
       return result;
     }, {});
 }

--- a/packages/canner-helpers/test/createFakeData.test.js
+++ b/packages/canner-helpers/test/createFakeData.test.js
@@ -254,7 +254,7 @@ describe('create relation empty data', () => {
   });
 
   it('should return toOne relation data ', () => {
-    expect(createFakeData({
+    expect(typeof createFakeData({
       posts: {
         keyName: 'posts',
         type: 'array',
@@ -275,7 +275,7 @@ describe('create relation empty data', () => {
           type: 'string'
         }
       }
-    }, 2).posts[0].author).not.toBe(null);
+    }, 2).posts[0].author).toBe('string');
   });
 
   it('should return {}', () => {

--- a/packages/canner-helpers/test/createFakeData.test.js
+++ b/packages/canner-helpers/test/createFakeData.test.js
@@ -157,6 +157,25 @@ describe('create object data', () => {
     expect(typeof data.boolean).toBe('boolean');
     expect(typeof data.number).toBe('number');
   });
+
+  it('should return array of object', () => {
+    const data = createFakeData({
+      type: 'object',
+      keyName: 'info',
+      items: {
+        hobbies: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
+      }
+    }, 5);
+    expect(data.info).toBeDefined();
+    expect(Array.isArray(data.info.hobbies)).toBe(true);
+    expect(data.info.hobbies.length).toBe(5);
+    expect(typeof data.info.hobbies[0]).toBe('string');
+  });
 });
 
 describe('create an array data', () => {

--- a/packages/canner-helpers/test/createFakeData.test.js
+++ b/packages/canner-helpers/test/createFakeData.test.js
@@ -235,12 +235,99 @@ describe('create relation empty data', () => {
     })).toBe(null);
   });
 
-  it('should return []', () => {
+  it('should return toOne relation data with null', () => {
+    expect(createFakeData({
+      posts: {
+        keyName: 'posts',
+        type: 'array',
+        items: {
+          author: {
+             type: 'relation',
+             relation: {
+               to: 'users',
+               type: 'toOne' 
+             } 
+          }
+        }
+      }
+    }, 2)).toEqual({"posts": [{"author": null, "id": "posts1"}, {"author": null, "id": "posts2"}]});
+  });
+
+  it('should return toOne relation data ', () => {
+    expect(createFakeData({
+      posts: {
+        keyName: 'posts',
+        type: 'array',
+        items: {
+          author: {
+             type: 'relation',
+             relation: {
+               to: 'users',
+               type: 'toOne' 
+             } 
+          }
+        }
+      },
+      users: {
+        type: 'array',
+        items: {
+          keyName: 'name',
+          type: 'string'
+        }
+      }
+    }, 2).posts[0].author).not.toBe(null);
+  });
+
+  it('should return {}', () => {
     expect(createFakeData({
       type: 'relation',
       relation: {
         type: 'toMany'
       }
-    })).toEqual([]);
+    })).toEqual({});
+  });
+
+  it('should return toMany relation data', () => {
+    expect(createFakeData({
+      posts: {
+        keyName: 'posts',
+        type: 'array',
+        items: {
+          authors: {
+             type: 'relation',
+             relation: {
+               to: 'users',
+               type: 'toMany' 
+             } 
+          }
+        }
+      }
+    }, 2)).toEqual({"posts": [{"authors": {}, "id": "posts1"}, {"authors": {}, "id": "posts2"}]});
+  });
+
+  it('should return toMany relation data', () => {
+    const data = createFakeData({
+      posts: {
+        keyName: 'posts',
+        type: 'array',
+        items: {
+          authors: {
+             type: 'relation',
+             relation: {
+               to: 'users',
+               type: 'toMany' 
+             } 
+          }
+        }
+      },
+      users: {
+        type: 'array',
+        items: {
+          keyName: 'name',
+          type: 'string'
+        }
+      }
+    }, 2).posts[0].authors;
+    expect(Object.keys(data)).toEqual(['users0', 'users1']);
   });
 })


### PR DESCRIPTION
Issue https://github.com/Canner/canner/issues/85

1. create the fake data of an inner array (length = 2)
```
{
  type: 'object',
  keyName: 'info',
  items: {
    hobbies: {
      type: 'array',
      items: {
        type: 'string'
      }
    }
  }
}
get data like this

{
 info: {
    hobbies: ['text1', 'text2']
  }
}
```

```
{
  type: 'object',
  keyName: 'info',
  items: {
    hobbies: {
      type: 'array',
      items: {
        keyName: 'name'
        type: 'string'
      }
    }
  }
}
get data like this

{
 info: {
    hobbies: [{ name: 'text1'}, {name: 'text2'}]
  }
}
```

2.  create the fake data of a relation field

Example for toOne

```
{
      posts: {
        keyName: 'posts',
        type: 'array',
        items: {
          author: {
             type: 'relation',
             relation: {
               to: 'users',
               type: 'toOne' 
             } 
          }
        }
      },
      users: {
        type: 'array',
        items: {
          keyName: 'name',
          type: 'string'
        }
      }
    }

would get data like

 {
    "posts": [{"author": "users2", "id": "posts1"},  {"author": "users2", "id": "posts2"}], 
    "users": [{"id": "users1", "name": "Music"}, {"id": "users2", "name": "South Carolina"}]
}

// If there is no `users` fields in this schema, it will return empty toOne relation data: null
```