### PR TITLE
Fix canner-router

### DIFF
--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -5,9 +5,7 @@ import historyRouter from '@canner/history-router';
 
 export default class Router extends historyRouter {
   constructor({baseUrl = '/'}: {baseUrl: string}) {
-    const history = createHistory({
-      basename: baseUrl,
-    })
+    const history = createHistory();
     super({baseUrl, history})
   }
 }


### PR DESCRIPTION
Remove passing basename to createHistory in router since `historyRouter` has already handled this.