### PR TITLE
Remove UNSAFE_ prefix of componentWillUnmount in example

### DIFF
--- a/examples/simple-ecommerce/customize/custom-relation-tree_toOne.js
+++ b/examples/simple-ecommerce/customize/custom-relation-tree_toOne.js
@@ -31,7 +31,7 @@ export default class RelationTree extends PureComponent {
     this.fetchData();
   }
 
-  UNSAFE_componentWillUnmount() {
+  componentWillUnmount() {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }


### PR DESCRIPTION
The life cycle method named componentWillUnmount is not need UNSAFE_ prefix.
The method which has been considered legacy is UNSAFE_componentWillMount(), actually.

Ref:
https://reactjs.org/docs/react-component.html#componentwillunmount
https://reactjs.org/docs/react-component.html#unsafe_componentwillmount