### PR TITLE
Improve validation with asynchronous pipeline

### DIFF
--- a/docs/schema/utils.js
+++ b/docs/schema/utils.js
@@ -3,9 +3,9 @@ import {Tooltip, Icon} from 'antd';
 import TableSelectColumn from "../components/columns/select";
 
 export const galleryValidation = {
-  validator: (content, reject) => {
+  validator: (content) => {
     if (content.length === 0) {
-      return reject("should at least have one photo");
+      return "should at least have one photo";
     }
   }
 };

--- a/packages/canner/src/hocs/types.js
+++ b/packages/canner/src/hocs/types.js
@@ -1,4 +1,4 @@
-// @flow
+g// @flow
 import type {Action, ActionType} from '../action/types';
 import type {Query} from '../query';
 import type RefId from 'canner-ref-id';
@@ -17,7 +17,7 @@ export type Subscribe = (key: string, callback: (data: any) => void) => Subscrip
 export type Deploy = (key: string, id?: string) => Promise<*>;
 export type OnDeploy = (key: string, callback: Function) => any;
 export type RemoveOnDeploy = (key: string, callbackId: string) => void;
-export type Validation = Object;
+export type Validation = {schema?: Object, erorrMessage?: string, validator?: (value: any) => string | Promise<string> | Promise<void> | void}
 export type UIParams = Object;
 export type Relation = Object;
 export type RenderChildren = any => React.Node

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -42,18 +42,22 @@ export default function withValidation(Com: React.ComponentType<*>) {
       const {value} = getValueAndPaths(result.data, paths);
       const isRequiredValid = required ? Boolean(value) : true;
 
+      const {schema, validator, errorMessage} = validation;
+      let validate = null
+
       // Ajv validation
-      const ajv = new Ajv();
-      const validate = ajv.compile(validation);
-      
+      if(schema && !isEmpty(schema)) {
+        const ajv = new Ajv();
+        validate = ajv.compile(schema);
+      }
       // custom validator
-      const {validator, errorMessage} = validation;
       const reject = message => ({error: true, message});
       const validatorResult = (validator && isFunction(validator) ) && validator(value, reject);
   
       let customValid = !(validatorResult && validatorResult.error);
+
       // if value is empty, should not validate with ajv
-      if (customValid && isRequiredValid && (!value || validate(value))) {
+      if (customValid && isRequiredValid && (!(value && isFunction(validate)) || validate(value))) {
         this.setState({
           error: false,
           errorInfo: []

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import RefId from 'canner-ref-id';
 import Ajv from 'ajv';
-import {isEmpty, isArray, isPlainObject, get} from 'lodash';
+import {isEmpty, isArray, isPlainObject, isFunction, get} from 'lodash';
 import type {HOCProps} from './types';
 
 type State = {
@@ -49,7 +49,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       // custom validator
       const {validator, errorMessage} = validation;
       const reject = message => ({error: true, message});
-      const validatorResult = validator && validator(value, reject);
+      const validatorResult = (validator && isFunction(validator) ) && validator(value, reject);
   
       let customValid = !(validatorResult && validatorResult.error);
       // if value is empty, should not validate with ajv

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -43,7 +43,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       const isRequiredValid = required ? Boolean(value) : true;
 
       const {schema, validator, errorMessage} = validation;
-      let validate = null
+      let validate = null;
 
       // Ajv validation
       if(schema && !isEmpty(schema)) {
@@ -52,7 +52,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       }
       // custom validator
       const reject = message => ({error: true, message});
-      const validatorResult = (validator && isFunction(validator) ) && validator(value, reject);
+      const validatorResult = (validator && isFunction(validator)) && validator(value, reject);
   
       let customValid = !(validatorResult && validatorResult.error);
 

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -12,7 +12,7 @@ type State = {
 }
 
 export default function withValidation(Com: React.ComponentType<*>) {
-  return class ComponentWithValition extends React.Component<HOCProps, State> {
+  return class ComponentWithValidation extends React.Component<HOCProps, State> {
     key: string;
     id: ?string;
     callbackId: ?string;

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -35,7 +35,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       this.removeOnDeploy();
     }
 
-    validate = (result: any) => {
+    validate = async (result: any) => {
       const {refId, validation = {}, required = false} = this.props;
       // required
       const paths = refId.getPathArr().slice(1);

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import RefId from 'canner-ref-id';
 import Ajv from 'ajv';
-import {isEmpty, isObject, isArray, isPlainObject, isFunction, get} from 'lodash';
+import {isEmpty, isObject, isArray, isPlainObject, isFunction, toString, get} from 'lodash';
 import type {HOCProps} from './types';
 
 type State = {
@@ -35,8 +35,8 @@ const _schemaValidation = (schema, errorMessage) => {
   const validate = ajv.compile(schema);
   return async (value) => {
     try {
-      const error = !validate(value)
-      const errorInfo = error ? [].concat( errorMessage ? {message: errorMessage} : validate.errors ) : []
+      const error = !validate(value);
+      const errorInfo = error ? [].concat( errorMessage ? {message: errorMessage} : validate.errors ) : [];
       return {
         error,
         errorInfo
@@ -45,7 +45,7 @@ const _schemaValidation = (schema, errorMessage) => {
     catch(err){
       return {
         error: true,
-        errorInfo: [{message: err}]
+        errorInfo: [{message: toString(err)}]
       }
     }
 
@@ -53,16 +53,18 @@ const _schemaValidation = (schema, errorMessage) => {
 }
 const _customizedValidator = (validator) => async (value) => {
   try {
-    const errorMessage = await validator(value)
+    const errorMessage = await validator(value);
+    const error = Boolean(errorMessage);
+    const errorInfo = error ? [{message: errorMessage}] : []
     return {
-      error: Boolean(errorMessage),
-      errorInfo: [{message: errorMessage}]
+      error,
+      errorInfo
     }
   }
   catch(err) {
     return {
       error: true,
-      errorInfo: [{message: err}]
+      errorInfo: [{message: toString(err)}]
     }
   }
 }

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -131,9 +131,13 @@ export default function withValidation(Com: React.ComponentType<*>) {
           if(value && checkSchema(schema)) {
             promiseQueue.push(_schemaValidation(schema, errorMessage)(value));
           }
-          if(checkValidator(validator)) {
-            promiseQueue.push(_customizedValidator(validator)(value));
-          }
+          if(validator) {
+            if(checkValidator(validator)) {
+              promiseQueue.push(_customizedValidator(validator)(value));
+            } else {
+              throw 'Validator should be a function'
+            }
+           }
         }
   
         const ValidationResult = await Promise.all(promiseQueue);
@@ -144,6 +148,10 @@ export default function withValidation(Com: React.ComponentType<*>) {
         }
       }
       catch(err){
+        this.setState({
+          error: true,
+          errorInfo: [].concat({message: toString(err)})
+        });
         return {
           ...result,
           error: true,

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -23,7 +23,7 @@ const checkValidator = (validator) => {
   return (isFunction(validator))
 }
 
-const keepRequired = async (value) => {
+const promiseRequired = async (value) => {
   const valid = Boolean(value)
   return {
     error: !valid,
@@ -31,7 +31,7 @@ const keepRequired = async (value) => {
   }
 }
 
-const keepSchemaValidation = (schema, errorMessage) => {
+const promiseSchemaValidation = (schema, errorMessage) => {
   const ajv = new Ajv();
   const validate = ajv.compile(schema);
   return async (value) => {
@@ -52,7 +52,7 @@ const keepSchemaValidation = (schema, errorMessage) => {
 
   }
 }
-const keepCustomizedValidator = (validator) => async (value) => {
+const promiseCustomizedValidator = (validator) => async (value) => {
   try {
     const errorMessage = await validator(value);
     const error = Boolean(errorMessage);
@@ -123,18 +123,18 @@ export default function withValidation(Com: React.ComponentType<*>) {
       try{
         // check whether value is required in first step
         if(required) {
-          promiseQueue.push(keepRequired(value));
+          promiseQueue.push(promiseRequired(value));
         }
   
         // skip validation if object validation is undefined or empty
         if(checkValidation(validation)) {
           const {schema, errorMessage, validator} = validation;
           if(value && checkSchema(schema)) {
-            promiseQueue.push(keepSchemaValidation(schema, errorMessage)(value));
+            promiseQueue.push(promiseSchemaValidation(schema, errorMessage)(value));
           }
           if(validator) {
             if(checkValidator(validator)) {
-              promiseQueue.push(keepCustomizedValidator(validator)(value));
+              promiseQueue.push(promiseCustomizedValidator(validator)(value));
             } else {
               throw 'Validator should be a function'
             }

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -23,7 +23,7 @@ const checkValidator = (validator) => {
   return (isFunction(validator))
 }
 
-const isRequiredValidation = async (value) => {
+const keepRequired = async (value) => {
   const valid = Boolean(value)
   return {
     error: !valid,
@@ -31,7 +31,7 @@ const isRequiredValidation = async (value) => {
   }
 }
 
-const schemaValidation = (schema, errorMessage) => {
+const keepSchemaValidation = (schema, errorMessage) => {
   const ajv = new Ajv();
   const validate = ajv.compile(schema);
   return async (value) => {
@@ -52,7 +52,7 @@ const schemaValidation = (schema, errorMessage) => {
 
   }
 }
-const customizedValidator = (validator) => async (value) => {
+const keepCustomizedValidator = (validator) => async (value) => {
   try {
     const errorMessage = await validator(value);
     const error = Boolean(errorMessage);
@@ -123,18 +123,18 @@ export default function withValidation(Com: React.ComponentType<*>) {
       try{
         // check whether value is required in first step
         if(required) {
-          promiseQueue.push(isRequiredValidation(value));
+          promiseQueue.push(keepRequired(value));
         }
   
         // skip validation if object validation is undefined or empty
         if(checkValidation(validation)) {
           const {schema, errorMessage, validator} = validation;
           if(value && checkSchema(schema)) {
-            promiseQueue.push(schemaValidation(schema, errorMessage)(value));
+            promiseQueue.push(keepSchemaValidation(schema, errorMessage)(value));
           }
           if(validator) {
             if(checkValidator(validator)) {
-              promiseQueue.push(customizedValidator(validator)(value));
+              promiseQueue.push(keepCustomizedValidator(validator)(value));
             } else {
               throw 'Validator should be a function'
             }

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -147,9 +147,9 @@ describe('withValidation', () => {
       onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       validation={
         {
-          validator: (content, reject) => {
+          validator: (content) => {
             if (!content) {
-              return reject('should be required');
+              return 'should be required';
             }
           }
         }

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import withValidationn from '../../src/hocs/validation';
+import withValidation from '../../src/hocs/validation';
 import RefId from 'canner-ref-id';
 
 
@@ -21,7 +21,7 @@ describe('withValidation', () => {
       onDeploy,
       removeOnDeploy
     }
-    WrapperComponent = withValidationn(MockComponent);
+    WrapperComponent = withValidation(MockComponent);
   });
 
   it('should error state = false', () => {

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -42,7 +42,7 @@ describe('withValidation', () => {
     expect(onDeploy).toBeCalledWith('posts', wrapper.instance().validate);
   });
 
-  it('should pass validation', () => {
+  it('should pass validation', async () => {
     const result = {
       data: {
         0: { url: 'https://'}
@@ -50,16 +50,16 @@ describe('withValidation', () => {
     };
     const wrapper =  mount(<WrapperComponent
       {...props}
-      onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       required
     />);
+    await wrapper.instance().validate(result)
     expect(wrapper.state()).toEqual({
       error: false,
       errorInfo: []
     })
   });
 
-  it('should not pass required validation', () => {
+  it('should not pass required validation', async () => {
     const result = {
       data: {
         0: { url: ''}
@@ -67,9 +67,9 @@ describe('withValidation', () => {
     };
     const wrapper =  mount(<WrapperComponent
       {...props}
-      onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       required
     />);
+    await wrapper.instance().validate(result)
     expect(wrapper.state()).toEqual({
       error: true,
       errorInfo: [{
@@ -78,7 +78,7 @@ describe('withValidation', () => {
     })
   });
 
-  it('should not pass ajv validation', () => {
+  it('should not pass ajv validation', async () => {
     const result = {
       data: {
         0: { url: 'imgurl.com'}
@@ -86,10 +86,10 @@ describe('withValidation', () => {
     };
     const wrapper =  mount(<WrapperComponent
       {...props}
-      onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       required
       validation={{schema: {pattern: '^http://[.]+'}}}
     />);
+    await wrapper.instance().validate(result)
     expect(wrapper.state()).toMatchObject({
       error: true,
       errorInfo: [{
@@ -98,7 +98,7 @@ describe('withValidation', () => {
     })
   });
 
-  it('should not pass ajv validation with custom error message', () => {
+  it('should not pass ajv validation with custom error message', async () => {
     const result = {
       data: {
         0: { url: 'imgurl.com'}
@@ -107,10 +107,10 @@ describe('withValidation', () => {
     const errorMessage = 'custom error';
     const wrapper =  mount(<WrapperComponent
       {...props}
-      onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       required
       validation={{schema: {pattern: '^http://[.]+'}, errorMessage}}
     />);
+    await wrapper.instance().validate(result)
     expect(wrapper.state()).toMatchObject({
       error: true,
       errorInfo: [{
@@ -119,7 +119,7 @@ describe('withValidation', () => {
     })
   });
 
-  it('should pass ajv validation if empty', () => {
+  it('should pass ajv validation if empty', async () => {
     const result = {
       data: {
         0: { url: ''}
@@ -127,16 +127,16 @@ describe('withValidation', () => {
     };
     const wrapper =  mount(<WrapperComponent
       {...props}
-      onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       validation={{schema: {pattern: '^http://[.]+'}}}
     />);
+    await wrapper.instance().validate(result)
     expect(wrapper.state()).toMatchObject({
       error: false,
       errorInfo: []
     })
   });
 
-  it('should use custom validation', () => {
+  it('should use custom validation', async () => {
     const result = {
       data: {
         0: { url: ''}
@@ -144,7 +144,6 @@ describe('withValidation', () => {
     };
     const wrapper =  mount(<WrapperComponent
       {...props}
-      onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       validation={
         {
           validator: (content) => {
@@ -155,6 +154,7 @@ describe('withValidation', () => {
         }
       }
     />);
+    await wrapper.instance().validate(result)
     expect(wrapper.state()).toMatchObject({
       error: true,
       errorInfo: [{

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -148,7 +148,7 @@ describe('withValidation', () => {
         {
           validator: (content) => {
             if (!content) {
-              return 'should be required';
+              return 'error message as return value';
             }
           }
         }
@@ -158,8 +158,55 @@ describe('withValidation', () => {
     expect(wrapper.state()).toMatchObject({
       error: true,
       errorInfo: [{
-        message: 'should be required'
+        message: 'error message as return value'
       }]
+    })
+  });
+
+  it('should use customized validator with throwing error', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: () => {
+              throw 'Throw error'
+          }
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: true,
+      errorInfo: [{
+        message: 'Throw error'
+      }]
+    })
+  });
+
+
+  it('should use customized validator with void return', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: () => {}
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: false,
+      errorInfo: []
     })
   });
 

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -136,7 +136,7 @@ describe('withValidation', () => {
     })
   });
 
-  it('should use custom validation', async () => {
+  it('should use customized validator with error message', async () => {
     const result = {
       data: {
         0: { url: ''}

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -4,6 +4,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import withValidation from '../../src/hocs/validation';
 import RefId from 'canner-ref-id';
 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -136,6 +137,7 @@ describe('withValidation', () => {
     })
   });
 
+  // Synchronous functions
   it('should use customized validator with error message', async () => {
     const result = {
       data: {
@@ -188,7 +190,6 @@ describe('withValidation', () => {
     })
   });
 
-
   it('should use customized validator with void return', async () => {
     const result = {
       data: {
@@ -210,6 +211,83 @@ describe('withValidation', () => {
     })
   });
 
+  // Async-await functions
+  it('should use customized async validator with error message', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: async (content) => {
+            await sleep(5)
+            if (!content) {
+              return 'error message as return value';
+            }
+          }
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: true,
+      errorInfo: [{
+        message: 'error message as return value'
+      }]
+    })
+  });
+
+  it('should use customized async validator with throwing error', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: async () => {
+            await sleep(5)
+            throw 'Throw error'
+          }
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: true,
+      errorInfo: [{
+        message: 'Throw error'
+      }]
+    })
+  });
+
+  it('should use customized async validator with void return', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: async () => { await sleep(5) }
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: false,
+      errorInfo: []
+    })
+  });
+
+  
   it('should removeOnDeploy not be called', () => {
     const wrapper = mount(<WrapperComponent
       {...props}

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -287,6 +287,80 @@ describe('withValidation', () => {
     })
   });
 
+  // Function with promise operation
+  it('should use customized validator with a Promise<string>', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: () => {
+            return new Promise(resolve => resolve('error message as resolved value'));
+          }
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: true,
+      errorInfo: [{
+        message: 'error message as resolved value'
+      }]
+    })
+  });
+
+  it('should use customized validator with a rejected Promise', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: () => {
+            return new Promise((resolve, reject) => {
+              reject(new Error('Rejected promise'));
+          })
+          }
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: true,
+      errorInfo: [{
+        message: 'Error: Rejected promise'
+      }]
+    })
+  });
+
+  it('should use customized validator with a Promise<void>', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: () => { return new Promise(resolve => resolve())}
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: false,
+      errorInfo: []
+    })
+  });
+
   
   it('should removeOnDeploy not be called', () => {
     const wrapper = mount(<WrapperComponent

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -88,7 +88,7 @@ describe('withValidation', () => {
       {...props}
       onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       required
-      validation={{pattern: '^http://[.]+'}}
+      validation={{schema: {pattern: '^http://[.]+'}}}
     />);
     expect(wrapper.state()).toMatchObject({
       error: true,
@@ -109,7 +109,7 @@ describe('withValidation', () => {
       {...props}
       onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
       required
-      validation={{pattern: '^http://[.]+', errorMessage}}
+      validation={{schema: {pattern: '^http://[.]+'}, errorMessage}}
     />);
     expect(wrapper.state()).toMatchObject({
       error: true,
@@ -128,7 +128,7 @@ describe('withValidation', () => {
     const wrapper =  mount(<WrapperComponent
       {...props}
       onDeploy={jest.fn().mockImplementation((_, fn) => (fn(result)))}
-      validation={{pattern: '^http://[.]+'}}
+      validation={{schema: {pattern: '^http://[.]+'}}}
     />);
     expect(wrapper.state()).toMatchObject({
       error: false,

--- a/packages/canner/test/hocs/validation.test.js
+++ b/packages/canner/test/hocs/validation.test.js
@@ -211,6 +211,29 @@ describe('withValidation', () => {
     })
   });
 
+  it('validator is not a function', async () => {
+    const result = {
+      data: {
+        0: { url: ''}
+      }
+    };
+    const wrapper =  mount(<WrapperComponent
+      {...props}
+      validation={
+        {
+          validator: 'validator'
+        }
+      }
+    />);
+    await wrapper.instance().validate(result)
+    expect(wrapper.state()).toMatchObject({
+      error: true,
+      errorInfo: [{
+        message: 'Validator should be a function'
+      }]
+    })
+  });
+
   // Async-await functions
   it('should use customized async validator with error message', async () => {
     const result = {


### PR DESCRIPTION
As reported in #173 #174 

There are some todo:

- [x] Add ```schema``` property to validation object
- [x] Only create Ajv instance when ```schema``` is verified as non-empty object
- [x] Completion of type definition
- [x] Implement asynchronous structure validation
- [x] Make customize support both (a)sync function
- [x] Check valid or invalid situation
- [x] Handle errors by promise chaining
- [x] Update and run test cases
- [x] Documentation